### PR TITLE
Remove blank line that made my erblint unhappy

### DIFF
--- a/test/dummy/app/views/frames/increment/button_in_frame.html.erb
+++ b/test/dummy/app/views/frames/increment/button_in_frame.html.erb
@@ -34,7 +34,6 @@
       <%= render component(:code), language: :html, class: "text-sm",
         path: "Rendered HTML for: /demos/2", source_path: "app/views/codes/increment/button_in_frame/show.html", erb: true %>
 
-
       <%= render component(:divider), class: "my-12" %>
 
       <%= button_to frame_path(params[:id]), method: :patch,


### PR DESCRIPTION
My app's `erblint`-ing was also looking into .erb files in node_modules and found something that made it unhappy.

Before PR:

```
$ erblint --lint-all --enable-linters space_around_erb_tag,extra_newline
.erb-lint.yml not found: using default config
Linting 70 files with 2 linters...

Extra blank line detected.
In file: test/dummy/app/views/frames/increment/button_in_frame.html.erb:37

1 error(s) were found in ERB files
```

After:

```
erblint --lint-all --enable-linters space_around_erb_tag,extra_newline
.erb-lint.yml not found: using default config
Linting 70 files with 2 linters...

No errors were found in ERB files
```