### PR TITLE
Base docs - prevent_controller_action is class method

### DIFF
--- a/lib/turbo_reflex/base.rb
+++ b/lib/turbo_reflex/base.rb
@@ -17,10 +17,13 @@ require_relative "attribute_set"
 # * render ...................... Renders Rails templates, partials, etc. (doesn't halt controller request handling)
 # * render_response ............. Renders a full controller response
 # * renderer .................... An ActionController::Renderer
-# * prevent_controller_action ... Prevents the rails controller/action from running (i.e. the reflex handles the response entirely)
 # * turbo_stream ................ A Turbo Stream TagBuilder
 # * turbo_streams ............... A list of Turbo Streams to append to the response (also aliased as streams)
 # * state ....................... An object that stores ephemeral `state`
+#
+# They also have access to the following class methods:
+#
+# * prevent_controller_action ... Prevents the rails controller/action from running (i.e. the reflex handles the response entirely)
 #
 class TurboReflex::Base
   class << self


### PR DESCRIPTION
Discovered I needed to invoke `prevent_controller_action` at the class level. Quick tweak to Base docs.

```ruby
class DemoReflex < TurboReflex::Base
  prevent_controller_action

  def myreflex
    # BYO morphing
  end
```