### PR TITLE
fix: cleanup some references to master branch

### DIFF
--- a/.github/workflows/prettier-standard.yml
+++ b/.github/workflows/prettier-standard.yml
@@ -6,14 +6,14 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   prettier:
     name: Prettier-Standard Check Action
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Setup Node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   standard:
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ruby-version: ['3.1']
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
@@ -34,4 +34,3 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run StandardRB
       run: bundle exec standardrb --format progress
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   ruby_test:
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:

--- a/turbo_reflex.gemspec
+++ b/turbo_reflex.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.metadata["homepage_uri"] = s.homepage
   s.metadata["source_code_uri"] = s.homepage
-  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
+  s.metadata["changelog_uri"] = s.homepage + "/blob/main/CHANGELOG.md"
 
   s.files = Dir["app/**/*", "bin/*", "config/*", "lib/**/*.rb", "[A-Z]*"]
 


### PR DESCRIPTION
The default branch of this repo is `main` but `master` is used in a few places. This commit updates those locations.

- Fix changelog link
- Update some references in the github actions